### PR TITLE
Issue #16 Preventing images that are not visible 

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -193,8 +193,10 @@ showAlt.onclick = function(element) {
 						body.classList.add('textaltcheck');
 						traverseForBackgrounds();
 						images.forEach(image => {
-							let alt = image.alt || 'Null';
-							wrap(image, alt)
+							if( image.offsetParent !== null){
+								let alt = image.alt || 'Null';
+								wrap(image, alt)
+							}
 						});
 					}
 					`


### PR DESCRIPTION
Images that have a display none or in an item that displays none will not get an overlay.